### PR TITLE
add sepia feature to Readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@
 | :--: | :--: | :--: |
 | <img src="./examples/charts/images/fruit_chart_with_text.png" width="250"> | <img src="./examples/charts/images/pie_chart.png" width="250"> | <img src="./examples/maps/parana_paracao_route.png" width="250"> |
 | <img src="./examples/image_processing/images/processed.jpg" width="250"> | <img src="./examples/charts/images/stem_plot.png" width="250"> | <img src="./examples/maps/parana_paracao_polygon.png" width="250"> |
+| <img src="./examples/basics/images/vintage.jpg" width="250">  |  |  |
+
+**Note:** The images shown in Table 1, along with the code used to generate them, are available in the `examples/` folder.
 
 # Native GD bindings for modern Ruby
+
 ## What is ruby-libgd?
 
 ruby-libgd is a modern native Ruby binding to the GD Graphics Library, providing Ruby with a fast, embeddable, server-side graphics engine.


### PR DESCRIPTION
<img width="1088" height="418" alt="Screenshot_20260105_231245" src="https://github.com/user-attachments/assets/c3f1dd24-e34e-4c08-be68-17b02576a52b" />
